### PR TITLE
refactor: Atualizar GitHub Actions para versões mais recentes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,7 +27,7 @@ jobs:
           cache: maven
           
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -46,18 +46,19 @@ jobs:
         run: mvn jacoco:report
         
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./target/site/jacoco/jacoco.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
           
       - name: Package application
         run: mvn package -DskipTests -B
         
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pip-platform-jar
           path: target/*.jar
@@ -92,7 +93,7 @@ jobs:
           args: --severity-threshold=high
           
       - name: Upload security scan results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: security-scan-results
@@ -120,7 +121,7 @@ jobs:
           cache: maven
           
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -186,7 +187,7 @@ jobs:
           output: 'trivy-results.sarif'
           
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
 


### PR DESCRIPTION
- Atualizar actions/upload-artifact de v3 para v4 (fix deprecation)
- Atualizar actions/cache de v3 para v4
- Atualizar codecov/codecov-action de v3 para v4 (adicionar token)
- Atualizar github/codeql-action/upload-sarif de v2 para v3

Fixes: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/