### PR TITLE
fix: Adicionar versão faltante na dependência flyway-database-postgresql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
+            <version>10.10.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>


### PR DESCRIPTION
- Adicionar version 10.10.0 para org.flywaydb:flyway-database-postgresql
- Corrigir erro de build: 'dependencies.dependency.version' is missing

Fixes Maven build error at line 45