### PR TITLE
fix: Corrigir import fora do lugar em WebhookScheduler.java

### DIFF
--- a/src/main/java/com/pip/service/WebhookScheduler.java
+++ b/src/main/java/com/pip/service/WebhookScheduler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Scheduler para processamento de webhooks pendentes e reenvio
@@ -196,5 +197,3 @@ public class WebhookScheduler {
         }
     }
 }
-
-import java.util.Map;


### PR DESCRIPTION
- Mover import java.util.Map para o topo do arquivo (linha 13)
- Remover import duplicado do final do arquivo (linha 200)
- Corrigir erro de compilação: 'class, interface, enum, or record expected'

Fixes Java compilation error at line 200